### PR TITLE
fix: improve fast keyboard navigation by handling simultaneous arrow keys

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,15 @@ export class DataGridNav {
     return el instanceof HTMLElement || el instanceof SVGElement;
   }
 
+  private isArrowKey(key: string): boolean {
+    return (
+      key === Keys.ArrowUp ||
+      key === Keys.ArrowDown ||
+      key === Keys.ArrowLeft ||
+      key === Keys.ArrowRight
+    );
+  }
+
   /** Used as a keyboard listener for key up */
   public tableKeyUp() {
     // TODO: have a cleanup as user can press key
@@ -210,7 +219,13 @@ export class DataGridNav {
     if (!(e.target instanceof Element)) return;
     if (!(target instanceof Element)) return;
 
-    if (this.keys.length === 1) {
+    // During rapid navigation, users may press the next arrow key
+    // before releasing the previous one. This ensures navigation
+    // still works when multiple arrow keys are held.
+    const isArrowCombo =
+      this.keys.length >= 2 && this.keys.every((key) => this.isArrowKey(key));
+
+    if (this.keys.length === 1 || isArrowCombo) {
       /**
        * Keys: Enter
        * Should move focus inside the cell to the first focusable element:

--- a/packages/storybook/__tests__/needle.test.tsx
+++ b/packages/storybook/__tests__/needle.test.tsx
@@ -123,4 +123,27 @@ describe('<Needle table />', () => {
     /** Expect first cell in the table, top left, to have focus */
     expect(firstCell).toHaveFocus();
   });
+
+  test('Rapid arrow key navigation - pressing next arrow before releasing previous', async () => {
+    const { container } = render(<NeedleTable />);
+
+    /**
+     * Click and focus to first cell of first
+     * row and then start keyboard navigation
+     */
+    const firstCell = getFirstCell(container);
+    await userEvent.click(firstCell);
+
+    /**
+     * Simulate rapid navigation where user presses ArrowRight
+     * while still holding ArrowDown (common during fast navigation)
+     */
+    await userEvent.keyboard('{ArrowDown>}{ArrowRight}{/ArrowDown}');
+
+    /** Should have moved down one row and right one cell */
+    const body = container.querySelectorAll('[role="rowgroup"]')[1];
+    const secondRow = body.querySelectorAll('[role="row"]')[1];
+    const secondCell = secondRow.querySelectorAll('[role="cell"]')[1];
+    expect(secondCell).toHaveFocus();
+  });
 });


### PR DESCRIPTION
I noticed that when navigating through a table quickly, some arrow key presses weren’t being registered. I found this was due to the fact I’d press the next arrow key before fully releasing the previous one, and the library only handled cases where one key was pressed.

I fixed this by checking if all keys pressed are arrow keys. In that case, jump in that direction.

In the videos below a before/after, but it's better to "feel" it yourself by quickly pressing ↑←  or press ← while you have the ↑ still pressed.

Before:

https://github.com/user-attachments/assets/ec6d736c-13a6-4984-94cc-e301c82984a3

After:

https://github.com/user-attachments/assets/515130c7-65dd-4d0c-9c8b-8d48c6fb7734

Thanks for your work on this library! ❤️